### PR TITLE
Ignore the meta.js.map file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 src
 test
 docs
+.dist/meta.js.map
 .test
 .babelrc
 .editorconfig


### PR DESCRIPTION
### Summary

Removes the transpilation map file from the npm package.